### PR TITLE
Allow including config files by default

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -36,4 +36,8 @@ class mackerel_agent::install(
   package { 'mackerel-agent':
     ensure => $ensure
   }
+
+  file { '/etc/mackerel-agent/conf.d':
+    ensure => directory,
+  }
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'mackerel_agent::install' do
   context 'with present (default)' do
     it { should contain_package('mackerel-agent').with_ensure('present') }
+    it { should contain_file('/etc/mackerel-agent/conf.d').with_ensure('directory') }
   end
 
   context 'with absent' do

--- a/templates/mackerel-agent.conf.erb
+++ b/templates/mackerel-agent.conf.erb
@@ -7,7 +7,7 @@ root = "."
 verbose = false
 
 # Include other config files
-# include = "/etc/mackerel-agent/conf.d/*.conf"
+include = "/etc/mackerel-agent/conf.d/*.conf"
 
 # Configuration for connection
 # [connection]


### PR DESCRIPTION
Using `/etc/mackerel-agent/conf.d`, I'd like to use custom metrics plugins.