### PR TITLE
Create parent directory for conf.d

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,10 +38,10 @@ class mackerel_agent::install(
   }
 
   file {
-    '/etc/mackerel-agent':
-      ensure => directory,
-
-    '/etc/mackerel-agent/conf.d':
+    [
+      '/etc/mackerel-agent',
+      '/etc/mackerel-agent/conf.d'
+    ]:
       ensure => directory,
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -37,7 +37,11 @@ class mackerel_agent::install(
     ensure => $ensure
   }
 
-  file { '/etc/mackerel-agent/conf.d':
-    ensure => directory,
+  file {
+    '/etc/mackerel-agent':
+      ensure => directory,
+
+    '/etc/mackerel-agent/conf.d':
+      ensure => directory,
   }
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'mackerel_agent::install' do
   context 'with present (default)' do
     it { should contain_package('mackerel-agent').with_ensure('present') }
+    it { should contain_file('/etc/mackerel-agent').with_ensure('directory') }
     it { should contain_file('/etc/mackerel-agent/conf.d').with_ensure('directory') }
   end
 


### PR DESCRIPTION
When I try creating /etc/mackerel-agent/conf.d, following error is occured.

```
Error: /Stage[main]/Mackerel_agent::Install/File[/etc/mackerel-agent/conf.d]/ensure: change from absent to directory failed: Cannot create /etc/mackerel-agent/conf.d;
parent directory /etc/mackerel-agent does not exist
```

So I want to create parent directory.