### PR TITLE
Support mackerel plugins

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,10 @@
 # == Class: mackerel_agent::config
 #
 class mackerel_agent::config(
-  $ensure  = present,
-  $apikey  = undef,
+  $ensure          = present,
+  $apikey          = undef,
+  $metrics_plugins = {},
+  $check_plugins   = {}
 ) {
   file { 'mackerel-agent.conf':
     ensure  => $ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class mackerel_agent(
     crit('apikey must be specified in the class paramerter.')
   } else {
     class { 'mackerel_agent::install':
-      ensure => $ensure
+      ensure            => $ensure,
       use_agent_plugins => $use_agent_plugins,
       use_check_plugins => $use_check_plugins
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,10 +20,36 @@
 #   Whether you want to mackerel-agent daemon to start up at boot
 #   Defaults to true
 #
+# [*use_metrics_plugins*]
+#   Whether you want to use official metrics plugins
+#   Defaults to undefined
+#
+# [*use_check_plugins*]
+#   Whether you want to use official check plugins
+#   Defaults to undefined
+#
+# [*metrics_plugins*]
+#   Metics plugin parameters
+#   Defualts to empty hash
+#
+# [*check_plugins*]
+#   Check plugin parameters
+#   Defualts to empty hash
+#
 # === Examples
 #
 #  class { 'mackerel_agent':
-#    apikey => 'Your API Key'
+#    apikey              => 'Your API Key'
+#    use_metrics_plugins => true,
+#    use_check_plugins   => true,
+#    metrics_plugins     => {
+#      apache2     => '/usr/local/bin/mackerel-plugin-apache2',
+#      php-opcache => '/usr/local/bin/mackerel-plugin-php-opcache'
+#    },
+#    check_plugins       => {
+#      access_log => '/usr/local/bin/check-log --file /var/log/access.log --pattern FATAL',
+#      check_cron => '/usr/local/bin/check-procs -p crond'
+#    }
 #  }
 #
 # === Authors

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,12 +35,12 @@
 # Copyright 2014 - 2015 Tomohiro TAIRA
 #
 class mackerel_agent(
-  $ensure            = present,
-  $apikey            = undef,
-  $service_ensure    = running,
-  $service_enable    = true,
-  $use_agent_plugins = undef,
-  $use_check_plugins = undef
+  $ensure              = present,
+  $apikey              = undef,
+  $service_ensure      = running,
+  $service_enable      = true,
+  $use_metrics_plugins = undef,
+  $use_check_plugins   = undef
 ) {
   validate_re($::osfamily, '^(RedHat|Debian)$', 'This module only works on RedHat or Debian based systems.')
   validate_string($apikey)
@@ -50,9 +50,9 @@ class mackerel_agent(
     crit('apikey must be specified in the class paramerter.')
   } else {
     class { 'mackerel_agent::install':
-      ensure            => $ensure,
-      use_agent_plugins => $use_agent_plugins,
-      use_check_plugins => $use_check_plugins
+      ensure              => $ensure,
+      use_metrics_plugins => $use_metrics_plugins,
+      use_check_plugins   => $use_check_plugins
     }
 
     class { 'mackerel_agent::config':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,10 +35,12 @@
 # Copyright 2014 - 2015 Tomohiro TAIRA
 #
 class mackerel_agent(
-  $ensure         = present,
-  $apikey         = undef,
-  $service_ensure = running,
-  $service_enable = true
+  $ensure            = present,
+  $apikey            = undef,
+  $service_ensure    = running,
+  $service_enable    = true,
+  $use_agent_plugins = undef,
+  $use_check_plugins = undef
 ) {
   validate_re($::osfamily, '^(RedHat|Debian)$', 'This module only works on RedHat or Debian based systems.')
   validate_string($apikey)
@@ -49,6 +51,8 @@ class mackerel_agent(
   } else {
     class { 'mackerel_agent::install':
       ensure => $ensure
+      use_agent_plugins => $use_agent_plugins,
+      use_check_plugins => $use_check_plugins
     }
 
     class { 'mackerel_agent::config':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,11 +40,15 @@ class mackerel_agent(
   $service_ensure      = running,
   $service_enable      = true,
   $use_metrics_plugins = undef,
-  $use_check_plugins   = undef
+  $use_check_plugins   = undef,
+  $metrics_plugins     = {},
+  $check_plugins       = {},
 ) {
   validate_re($::osfamily, '^(RedHat|Debian)$', 'This module only works on RedHat or Debian based systems.')
   validate_string($apikey)
   validate_bool($service_enable)
+  validate_hash($metrics_plugins)
+  validate_hash($check_plugins)
 
   if $apikey == undef {
     crit('apikey must be specified in the class paramerter.')
@@ -56,8 +60,10 @@ class mackerel_agent(
     }
 
     class { 'mackerel_agent::config':
-      apikey  => $apikey,
-      require => Class['mackerel_agent::install']
+      apikey          => $apikey,
+      metrics_plugins => $metrics_plugins,
+      check_plugins   => $check_plugins,
+      require         => Class['mackerel_agent::install']
     }
 
     class { 'mackerel_agent::service':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -54,6 +54,9 @@ class mackerel_agent::install(
         ensure => absent
       }
     }
+    default: {
+      # Do nothing
+    }
   }
 
   case $use_check_plugins {
@@ -66,6 +69,9 @@ class mackerel_agent::install(
       package { 'mackarel-check-plugins':
         ensure => absent
       }
+    }
+    default: {
+      # Do nothing
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,9 @@
 # == Class: mackerel_agent::install
 #
 class mackerel_agent::install(
-  $ensure = present
+  $ensure = present,
+  $use_agent_plugins = undef,
+  $use_check_plugins = undef
 ) {
   $gpgkey_url = 'https://mackerel.io/assets/files/GPG-KEY-mackerel'
 
@@ -39,5 +41,31 @@ class mackerel_agent::install(
 
   file { '/etc/mackerel-agent/conf.d':
     ensure => directory,
+  }
+
+  case $use_agent_plugins {
+    true: {
+      package { 'mackarel-agent-plugins':
+        ensure => present
+      }
+    }
+    false: {
+      package { 'mackarel-agent-plugins':
+        ensure => absent
+      }
+    }
+  }
+
+  case $use_check_plugins {
+    true: {
+      package { 'mackarel-check-plugins':
+        ensure => present
+      }
+    }
+    false: {
+      package { 'mackarel-check-plugins':
+        ensure => absent
+      }
+    }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,9 +1,9 @@
 # == Class: mackerel_agent::install
 #
 class mackerel_agent::install(
-  $ensure = present,
-  $use_agent_plugins = undef,
-  $use_check_plugins = undef
+  $ensure              = present,
+  $use_metrics_plugins = undef,
+  $use_check_plugins   = undef
 ) {
   $gpgkey_url = 'https://mackerel.io/assets/files/GPG-KEY-mackerel'
 
@@ -43,7 +43,7 @@ class mackerel_agent::install(
     ensure => directory,
   }
 
-  case $use_agent_plugins {
+  case $use_metrics_plugins {
     true: {
       package { 'mackerel-agent-plugins':
         ensure => present

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -45,12 +45,12 @@ class mackerel_agent::install(
 
   case $use_agent_plugins {
     true: {
-      package { 'mackarel-agent-plugins':
+      package { 'mackerel-agent-plugins':
         ensure => present
       }
     }
     false: {
-      package { 'mackarel-agent-plugins':
+      package { 'mackerel-agent-plugins':
         ensure => absent
       }
     }
@@ -61,12 +61,12 @@ class mackerel_agent::install(
 
   case $use_check_plugins {
     true: {
-      package { 'mackarel-check-plugins':
+      package { 'mackerel-check-plugins':
         ensure => present
       }
     }
     false: {
-      package { 'mackarel-check-plugins':
+      package { 'mackerel-check-plugins':
         ensure => absent
       }
     }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -16,7 +16,7 @@ describe 'mackerel_agent::install' do
 
   context 'with mackerel agent plugins' do
     let(:params) do
-      { :use_agent_plugins => true }
+      { :use_metrics_plugins => true }
     end
 
     it { should contain_package('mackerel-agent-plugins').with_ensure('present') }
@@ -24,7 +24,7 @@ describe 'mackerel_agent::install' do
 
   context 'without mackerel agent plugins' do
     let(:params) do
-      { :use_agent_plugins => false }
+      { :use_metrics_plugins => false }
     end
 
     it { should contain_package('mackerel-agent-plugins').with_ensure('absent') }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -13,4 +13,37 @@ describe 'mackerel_agent::install' do
 
     it { should contain_package('mackerel-agent').with_ensure('absent') }
   end
+
+  context 'with mackerel agent plugins' do
+    let(:params) do
+      { :use_agent_plugins => true }
+    end
+
+    it { should contain_package('mackerel-agent-plugins').with_ensure('present') }
+  end
+
+  context 'without mackerel agent plugins' do
+    let(:params) do
+      { :use_agent_plugins => false }
+    end
+
+    it { should contain_package('mackerel-agent-plugins').with_ensure('absent') }
+  end
+
+
+  context 'with mackerel check plugins' do
+    let(:params) do
+      { :use_check_plugins => true }
+    end
+
+    it { should contain_package('mackerel-check-plugins').with_ensure('present') }
+  end
+
+  context 'without mackerel check plugins' do
+    let(:params) do
+      { :use_check_plugins => false }
+    end
+
+    it { should contain_package('mackerel-check-plugins').with_ensure('absent') }
+  end
 end

--- a/templates/mackerel-agent.conf.erb
+++ b/templates/mackerel-agent.conf.erb
@@ -17,9 +17,21 @@ include = "/etc/mackerel-agent/conf.d/*.conf"
 # post_metrics_buffer_size = 30           # max numbers of requests stored in buffer queue.
 
 # Configuration for Custom Metrics Plugins
-# see also: http://help-ja.mackerel.io/entry/advanced/custom-metrics
 #
-# [plugin.metrics.vmstat]
-# command = "ruby /path/to/plugins/metrics-vmstat.rb"
-# [plugin.metrics.curl]
-# command = "ruby /path/to/plugins/metrics-curl.rb"
+# followings are mackerel-agent-plugins
+#   help: http://help.mackerel.io/entry/howto/mackerel-agent-plugins
+#   repository: https://github.com/mackerelio/mackerel-agent-plugins
+<% @metrics_plugins.each do |plugin, command| %>
+[plugin.metrics.<%= plugin %>]
+command = "<%= command %>"
+<% end %>
+
+# Configuration for Custom Check Plugins
+#
+# followings are go-check-plugins
+#   help: http://help.mackerel.io/entry/howto/mackerel-check-plugins
+#   repository: https://github.com/mackerelio/go-check-plugins
+<% @check_plugins.each do |plugin, command| %>
+[plugin.checks.<%= plugin %>]
+command = "<%= command %>"
+<% end %>

--- a/test/manifests/site.pp
+++ b/test/manifests/site.pp
@@ -12,5 +12,13 @@
 class { 'mackerel_agent':
   apikey              => $apikey,
   use_metrics_plugins => true,
-  use_check_plugins   => true
+  use_check_plugins   => true,
+  metrics_plugins     => {
+    php-apc     => '/usr/local/bin/mackerel-plugin-php-apc',
+    php-opcache => '/usr/local/bin/mackerel-plugin-php-opcache'
+  },
+  check_plugins       => {
+    access_log => '/usr/local/bin/check-log --file /var/log/access.log --pattern FATAL',
+    check_cron => '/usr/local/bin/check-procs -p crond'
+  }
 }

--- a/test/manifests/site.pp
+++ b/test/manifests/site.pp
@@ -14,7 +14,7 @@ class { 'mackerel_agent':
   use_metrics_plugins => true,
   use_check_plugins   => true,
   metrics_plugins     => {
-    php-apc     => '/usr/local/bin/mackerel-plugin-php-apc',
+    apache2     => '/usr/local/bin/mackerel-plugin-apache2',
     php-opcache => '/usr/local/bin/mackerel-plugin-php-opcache'
   },
   check_plugins       => {

--- a/test/manifests/site.pp
+++ b/test/manifests/site.pp
@@ -10,5 +10,7 @@
 # http://docs.puppetlabs.com/guides/tests_smoke.html
 #
 class { 'mackerel_agent':
-  apikey => $apikey
+  apikey            => $apikey,
+  use_agent_plugins => true,
+  use_check_plugins => true
 }

--- a/test/manifests/site.pp
+++ b/test/manifests/site.pp
@@ -10,7 +10,7 @@
 # http://docs.puppetlabs.com/guides/tests_smoke.html
 #
 class { 'mackerel_agent':
-  apikey            => $apikey,
-  use_agent_plugins => true,
-  use_check_plugins => true
+  apikey              => $apikey,
+  use_metrics_plugins => true,
+  use_check_plugins   => true
 }


### PR DESCRIPTION
Support these plugins

- [mackerel-agent-plugin](http://help.mackerel.io/entry/howto/mackerel-agent-plugins)
- [mackerel-check-plugin](http://help.mackerel.io/entry/howto/mackerel-check-plugins)

### Example

```puppet
class { 'mackerel-agent':
  ensure              => present,
  use_metrics_plugins => true,
  use_check_plugins   => true,
  metrics_plugins     => {
    apache2     => '/usr/local/bin/mackerel-plugin-apache2',
    php-opcache => '/usr/local/bin/mackerel-plugin-php-opcache'
  },
  check_plugins       => {
    access_log => '/usr/local/bin/check-log --file /var/log/access.log --pattern FATAL',
    check_cron => '/usr/local/bin/check-procs -p crond'
  }
}
```