### PR TITLE
Support latest apt module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ matrix:
       services: docker
       env: BEAKER_set=centos-6-x64
       script: bundle exec rake beaker
+    - rvm: default
+      sudo: required
+      services: docker
+      env: BEAKER_set=ubuntu-14.04-x64
+      script: bundle exec rake beaker
 
 notifications:
   email: false

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,11 @@ class mackerel_agent::config(
   $metrics_plugins = {},
   $check_plugins   = {}
 ) {
+  file { '/etc/mackerel-agent/conf.d':
+    ensure  => directory,
+    require => Package['mackerel-agent']
+  }
+
   file { 'mackerel-agent.conf':
     ensure  => $ensure,
     path    => '/etc/mackerel-agent/mackerel-agent.conf',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,18 +20,18 @@ class mackerel_agent::install(
     }
     'Debian': {
       apt::key { 'mackerel':
-        id      => '2748FD61027D357542F8394DF92F673FC2B48821',
-        source  => $gpgkey_url
+        id     => '2748FD61027D357542F8394DF92F673FC2B48821',
+        source => $gpgkey_url
       }
 
       apt::source { 'mackerel':
-        location    => 'http://apt.mackerel.io/debian/',
-        release     => 'mackerel',
-        repos       => 'contrib',
-        include     => {
+        location => 'http://apt.mackerel.io/debian/',
+        release  => 'mackerel',
+        repos    => 'contrib',
+        include  => {
           source => false
         },
-        require     => Apt::Key['mackerel']
+        require  => Apt::Key['mackerel']
       }
     }
     default: {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,28 +20,27 @@ class mackerel_agent::install(
     }
     'Debian': {
       apt::key { 'mackerel':
-        key        => 'C2B48821',
-        key_source => $gpgkey_url
+        id      => '2748FD61027D357542F8394DF92F673FC2B48821',
+        source  => $gpgkey_url
       }
+
       apt::source { 'mackerel':
         location    => 'http://apt.mackerel.io/debian/',
         release     => 'mackerel',
         repos       => 'contrib',
-        include_src => false
+        include     => {
+          source => false
+        },
+        require     => Apt::Key['mackerel']
       }
     }
     default: {
       # Do nothing
     }
-  }
+  } ->
 
   package { 'mackerel-agent':
     ensure => $ensure
-  }
-
-  file { '/etc/mackerel-agent/conf.d':
-    ensure  => directory,
-    require => Package['mackerel-agent']
   }
 
   case $use_metrics_plugins {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,8 @@ class mackerel_agent::service(
   $enable = true,
 ) {
   service { 'mackerel-agent':
-    ensure => $ensure,
-    enable => $enable
+    ensure     => $ensure,
+    enable     => $enable,
+    hasrestart => true
   }
 }

--- a/spec/acceptance/nodesets/ubuntu-14.04-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-14.04-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  ubuntu-14.04-x64:
+    platform: ubuntu-14.04-x64
+    image: ubuntu:trusty
+    hypervisor: docker
+    docker_preserve_image: true
+CONFIG:
+  type: foss
+  log_level: debug
+  masterless: true

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'mackerel_agent::config' do
   context 'with present (default)' do
     it { should contain_file('mackerel-agent.conf').with_ensure('present') }
+    it { should contain_file('/etc/mackerel-agent/conf.d').with_ensure('directory') }
   end
 
   context 'with absent' do

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe 'mackerel_agent::install' do
   context 'with present (default)' do
     it { should contain_package('mackerel-agent').with_ensure('present') }
-    it { should contain_file('/etc/mackerel-agent/conf.d').with_ensure('directory') }
   end
 
   context 'with absent' do


### PR DESCRIPTION
- [puppetlabs/apt · Puppet Forge](https://forge.puppetlabs.com/puppetlabs/apt)
- [puppetlabs-apt/CHANGELOG.md at master · puppetlabs/puppetlabs-apt](https://github.com/puppetlabs/puppetlabs-apt/blob/master/CHANGELOG.md#aptkey)

Latest API:

```
apt::key { 'puppetlabs':
  id      => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
  server  => 'pgp.mit.edu',
  options => 'http-proxy="http://proxyuser:proxypass@example.org:3128"',
}
```