### PR TITLE
Add other parameters for check_plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ class { 'mackerel_agent':
   check_plugins       => {
     access_log => '/usr/local/bin/check-log --file /var/log/access.log --pattern FATAL',
     check_cron => '/usr/local/bin/check-procs -p crond'
+    check_ssh  => {
+      command               => 'ruby /path/to/check-ssh.rb',
+      notification_interval => '60',
+      max_check_attempts    => '3',
+      check_interval        => '5'
+    }
   }
 }
 ```
@@ -76,6 +82,11 @@ mackerel_agent::metrics_plugins:
 mackerel_agent::check_plugins:
   access_log: '/usr/local/bin/check-log --file /var/log/access.log --pattern FATAL'
   check_cron: '/usr/local/bin/check-procs -p crond'
+  ssh:
+    command: 'ruby /path/to/check-ssh.rb'
+    notification_interval: '60'
+    max_check_attempts: '3'
+    check_interval: '5'
 ```
 
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -37,4 +37,19 @@ describe 'mackerel_agent::config' do
 
     it { should contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[filesystems\]\nignore = "/dev/ram.*"$}) }
   end
+
+  context 'with check_plugins' do
+    let(:params) do
+      { :check_plugins => { 'access_log' => '/usr/local/bin/check-log --file /var/log/access.log --pattern FATAL' } }
+    end
+    it { should contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.checks.*\]\ncommand = \".*\"$}) }
+  end
+
+  context 'with check_plugins on some parameters' do
+    let(:params) do
+      { :check_plugins => { 'ssh' => { 'command' => 'ruby /path/to/check-ssh.rb', 'notification_interval' => '6', 'max_check_attempts' => '3', 'check_interval' => '5'} } }
+    end
+    it { should contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.checks.*\]\ncommand = \".*\"\nnotification_interval = \".*\"\nmax_check_attempts = \".*\"\ncheck_interval = \".*\"$}) }
+  end
+
 end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -49,7 +49,7 @@ describe 'mackerel_agent::config' do
     let(:params) do
       { :check_plugins => { 'ssh' => { 'command' => 'ruby /path/to/check-ssh.rb', 'notification_interval' => '6', 'max_check_attempts' => '3', 'check_interval' => '5'} } }
     end
-    it { should contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.checks.*\]\ncommand = \".*\"\nnotification_interval = \".*\"\nmax_check_attempts = \".*\"\ncheck_interval = \".*\"$}) }
+    it { should contain_file('mackerel-agent.conf').with_ensure('present').with_content(%r{^\[plugin.checks.*\]\ncommand = \".*\"\nnotification_interval = .*\nmax_check_attempts = .*\ncheck_interval = .*$}) }
   end
 
 end

--- a/templates/mackerel-agent.conf.erb
+++ b/templates/mackerel-agent.conf.erb
@@ -46,7 +46,17 @@ command = "<%= command %>"
 # followings are go-check-plugins
 #   help: http://help.mackerel.io/entry/howto/mackerel-check-plugins
 #   repository: https://github.com/mackerelio/go-check-plugins
-<% @check_plugins.each do |plugin, command| %>
+<% @check_plugins.each do |plugin, parameters| %>
 [plugin.checks.<%= plugin %>]
-command = "<%= command %>"
+<% if parameters.is_a?(Hash) -%>
+<% parameters.each do |param, data| -%>
+<% if data =~ /^[0-9]+$/ -%>
+<%= param %> = <%= data %>
+<% else -%>
+<%= param %> = "<%= data %>"
+<% end -%>
+<% end -%>
+<% else -%>
+command = "<%= parameters %>"
+<% end -%>
 <% end %>


### PR DESCRIPTION
Paramter in check plugins can be set with not only "command" but also "notification_interval" and  "max_check_attempts" and so on as mentioned in [the official document](https://mackerel.io/docs/entry/custom-checks).
This change will enable more flexible settings.