### PR TITLE
Define missing facts in classes spec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 RSpec.configure do |c|
-  c.default_facts = { :osfamily => 'RedHat' }
+  c.default_facts = {
+    :architecture => 'amd64',
+    :osfamily => 'RedHat',
+    :operatingsystem => 'CentOS',
+  }
 end


### PR DESCRIPTION
Since v1.2.0 puppetlabs_spec_helper performs strict variable checking when used with Puppet 4. This patch defines facts used in the manifests to pass the specs.