### PR TITLE
Raise the upper limit of puppetlabs-apt version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
 
   include:
     # Unit tests
-    - rvm: 1.9.3
+    - rvm: 2.1.9
       env: PUPPET_GEM_VERSION='~> 3.0'
-    - rvm: 1.9.3
+    - rvm: 2.1.9
       env: PUPPET_GEM_VERSION='~> 4.0'
     - rvm: 2.3.0
       env: PUPPET_GEM_VERSION='~> 4.0'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,19 +30,18 @@ class mackerel_agent::install(
       $pkg_require = Yumrepo['mackerel']
     }
     'Debian': {
-      apt::key { 'mackerel':
-        id     => '2748FD61027D357542F8394DF92F673FC2B48821',
-        source => $gpgkey_url
-      }
 
       apt::source { 'mackerel':
         location => 'http://apt.mackerel.io/debian/',
         release  => 'mackerel',
         repos    => 'contrib',
+        key      =>  {
+          id     => '2748FD61027D357542F8394DF92F673FC2B48821',
+          source => $gpgkey_url
+        },
         include  => {
           source => false
         },
-        require  => Apt::Key['mackerel'],
       }
 
       $pkg_require = Class['apt::update']

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.0.0 <2.2.0"
+      "version_requirement": ">=2.0.0 <5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
puppetlabs-apt has released version 4.0.0 for supporting Puppet 4.x.