### PR TITLE
Support mackerel-agent v2 repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
       services: docker
       env: BEAKER_set=ubuntu-14.04-x64
       script: bundle exec rake beaker
+    - rvm: default
+      sudo: required
+      services: docker
+      env: BEAKER_set=debian-9-x64
+      script: bundle exec rake beaker
 
 notifications:
   email: false

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,16 +5,22 @@ class mackerel_agent::install(
   $use_metrics_plugins = undef,
   $use_check_plugins   = undef
 ) {
-  $gpgkey_url = 'https://mackerel.io/assets/files/GPG-KEY-mackerel'
 
   case $::osfamily {
     'RedHat': {
       case $::operatingsystem {
         'Amazon': {
           $baseurl = 'http://yum.mackerel.io/amznlinux/$releasever/$basearch'
+          $gpgkey_url = 'https://mackerel.io/assets/files/GPG-KEY-mackerel'
         }
         default: {
-          $baseurl = 'http://yum.mackerel.io/centos/$basearch'
+          if $::operatingsystemmajrelease == '6' {
+            $baseurl = 'http://yum.mackerel.io/centos/$basearch'
+            $gpgkey_url = 'https://mackerel.io/assets/files/GPG-KEY-mackerel'
+          } else {
+            $baseurl = 'http://yum.mackerel.io/v2/$basearch'
+            $gpgkey_url = 'https://mackerel.io/file/cert/GPG-KEY-mackerel-v2'
+          }
         }
       }
 
@@ -30,13 +36,40 @@ class mackerel_agent::install(
       $pkg_require = Yumrepo['mackerel']
     }
     'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if $::operatingsystemmajrelease == '7' {
+            $location = 'http://apt.mackerel.io/debian/'
+            $id = '2748FD61027D357542F8394DF92F673FC2B48821'
+            $gpgkey_url = 'https://mackerel.io/assets/files/GPG-KEY-mackerel'
+          } else {
+            $location = 'http://apt.mackerel.io/v2/'
+            $id = '9DD9479D06BAA71322803AC166332B78417E73EA'
+            $gpgkey_url = 'https://mackerel.io/file/cert/GPG-KEY-mackerel-v2'
+          }
+        }
+        'Ubuntu': {
+          if $::operatingsystemmajrelease == '14.04' {
+            $location = 'http://apt.mackerel.io/debian/'
+            $id = '2748FD61027D357542F8394DF92F673FC2B48821'
+            $gpgkey_url = 'https://mackerel.io/assets/files/GPG-KEY-mackerel'
+          } else {
+            $location = 'http://apt.mackerel.io/v2/'
+            $id = '9DD9479D06BAA71322803AC166332B78417E73EA'
+            $gpgkey_url = 'https://mackerel.io/file/cert/GPG-KEY-mackerel-v2'
+          }
+        }
+        default: {
+          # Do nothing
+        }
+      }
 
       apt::source { 'mackerel':
-        location => 'http://apt.mackerel.io/debian/',
+        location => $location,
         release  => 'mackerel',
         repos    => 'contrib',
         key      =>  {
-          id     => '2748FD61027D357542F8394DF92F673FC2B48821',
+          id     => $id,
           source => $gpgkey_url
         },
         include  => {

--- a/spec/acceptance/nodesets/debian-9-x64.yml
+++ b/spec/acceptance/nodesets/debian-9-x64.yml
@@ -4,6 +4,8 @@ HOSTS:
     image: debian:stretch
     hypervisor: docker
     docker_preserve_image: true
+    docker_image_commands:
+      - 'apt-get install -y wget'
 CONFIG:
   type: foss
   log_level: debug

--- a/spec/acceptance/nodesets/debian-9-x64.yml
+++ b/spec/acceptance/nodesets/debian-9-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  debian-9-x64:
+    platform: debian-9-x64
+    image: debian:stretch
+    hypervisor: docker
+    docker_preserve_image: true
+CONFIG:
+  type: foss
+  log_level: debug
+  masterless: true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,5 +5,6 @@ RSpec.configure do |c|
     :architecture => 'amd64',
     :osfamily => 'RedHat',
     :operatingsystem => 'CentOS',
+    :operatingsystemmajrelease => '7',
   }
 end


### PR DESCRIPTION
@Tomohiro 

I added support for mackerel-agent v2 in EL7, Ubuntu 16.04, and Debian 8 and later.

- https://mackerel.io/file/script/setup-all-yum-v2.sh
- https://mackerel.io/file/script/setup-all-apt-v2.sh